### PR TITLE
chore: add jira integration to release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,3 +134,26 @@ jobs:
                   generate_release_notes: true
                   files: |
                       dist/${{ needs.build.outputs.artifact_name }}.zip
+
+    jira:
+        name: Update Jira Issue
+        runs-on: ubuntu-latest
+        needs: release
+        if: needs.version-check.outputs.should_continue == 'true' && needs.version-check.outputs.version != '' && needs.version-check.outputs.test != 'true'
+        steps:
+            - name: Find issue key
+              id: find
+              uses: atlassian/gajira-find-issue-key@v3
+              with:
+                  string: ${{ github.event.head_commit.message }}
+
+            - name: Transition issue to Released
+              if: steps.find.outputs.issue != ''
+              uses: atlassian/gajira-transition@v3
+              with:
+                  issue: ${{ steps.find.outputs.issue }}
+                  transition: "Released"
+              env:
+                  JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+                  JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+                  JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}


### PR DESCRIPTION
## Summary
- update release workflow to update Jira issue based on commit message

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: console is not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a3c565f93c832388d9a06edcc17dba